### PR TITLE
fixed multiple error prints issue

### DIFF
--- a/com/familytree/Family.py
+++ b/com/familytree/Family.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 # from com.familytree.Tree import Tree
+from com.familytree.TreeError import TreeError
 from com.familytree.TreeUtils import TreeUtils
 
 
@@ -12,6 +13,8 @@ class Family:
         self.wife = None
         self.chil = []
         self.div = None
+        self.err = None
+        self.err_list = []
         self.tag_name = TreeUtils.FAM
         self.src_file = src_file
 
@@ -57,6 +60,9 @@ class Family:
 
     def get_wife_birth_date(self, family_tree):
         return family_tree.get(self.wife).get_birth_date() if family_tree.get(self.wife) else None
+
+    def add_err(self, err_type, us_name, err_msg):
+        self.err_list.append(TreeError(err_type, TreeError.ON_FAM, us_name, self.id, err_msg))
 
     def get_children(self, family_tree=None):
         # TODO can use lambda :D

--- a/com/familytree/Individual.py
+++ b/com/familytree/Individual.py
@@ -17,6 +17,7 @@ class Individual:
         self.famc = None
         self.fams = []
         self.err = None
+        self.err_list = []
         self.tag_name = TreeUtils.INDI
         self.src_file = src_file
 
@@ -168,8 +169,8 @@ class Individual:
             return self.famc
         return family_tree.get(self.famc)
 
-    def add_error(self, us_name, err_msg):
-        self.err = TreeError(TreeError.TYPE_ERROR, TreeError.ON_INDI, us_name, self.id, err_msg)
+    def add_err(self, err_type, us_name, err_msg):
+        self.err_list.append(TreeError(err_type, TreeError.ON_INDI, us_name, self.id, err_msg))
 
     # get a cleaned up version of the id
     @staticmethod

--- a/com/familytree/TreeUtils.py
+++ b/com/familytree/TreeUtils.py
@@ -48,11 +48,16 @@ class TreeUtils:
 
     @staticmethod
     def print_report(report_name, obj_list):
-        TreeUtils.logger.error(f'\n{TreeUtils.form_heading(f"Report - {report_name}")}\n')
+        logger = TreeUtils.get_logger()
+        logger.error(f'\n{TreeUtils.form_heading(f"Report - {report_name}")}\n')
         # print(f'\n{TreeUtils.form_heading(f"Report - {report_name}")}\n')
         for obj in obj_list:
-            TreeUtils.logger.error(obj.err)
-            # print(obj.err)
+            if obj.err_list:
+                # logger.error(f'{obj.id} error list size [{len(obj.err_list)}]')
+                for err in obj.err_list:
+                    logger.error(err)
+            else:
+                logger.error(obj.err)
 
     @staticmethod
     def get_logger():

--- a/com/familytree/sprints/Sprint.py
+++ b/com/familytree/sprints/Sprint.py
@@ -19,10 +19,8 @@ class Sprint:
     def run_sprint1():
         error_list = []
         fp = get_data_file_path('data_sprint_1.ged')
-        Sprint.logger.error('#################### starting sprint 1 ... ####################')
+        Sprint.logger.error('######################################## starting sprint 1 ... ########################################')
         try:
-            # TODO there is some weird behavior with chained method calls on new object
-            #  Tree().grow(fp).pretty_print()
             tree = Tree().grow(fp).pretty_print()
             usny, usmsk, usam, usdg, usrk = UserStoriesNy(), UserStoriesMSK(), UserStoriesAm(), UserStoriesDg(), UserStoriesRK()
             error_list.extend(usmsk.us09(fp))
@@ -36,39 +34,43 @@ class Sprint:
             error_list.extend(usrk.us03(fp))
             error_list.extend(usrk.us04(fp))
             TreeUtils.print_report('Sprint 1 Report', error_list)
-            Sprint.logger.error('#################### ending sprint 1 ... ####################')
         except FileNotFoundError:
             print(f'File not found: {fp}')
+        Sprint.logger.error('######################################## ending sprint 1 ... ########################################\n')
 
     @staticmethod
     def run_sprint2():
         error_list = []
         fp = get_data_file_path('data_sprint_2.ged')
-        Sprint.logger.error('#################### starting sprint 2 ... ####################')
-        Tree().grow(fp).pretty_print()
-        usny, usmsk, usam, usdg, usrk = UserStoriesNy(), UserStoriesMSK(), UserStoriesAm(), UserStoriesDg(), UserStoriesRK()
-        error_list.extend(usny.us13(fp))
-        error_list.extend(usny.us19(fp))
-        error_list.extend(usdg.us15(fp))
-        error_list.extend(usdg.us12(fp))
-        error_list.extend(usrk.us14(fp))
-        error_list.extend(usrk.us21(fp))
-        error_list.extend(usam.us11(fp))
-        error_list.extend(usam.us16(fp))
-        TreeUtils.print_report('Sprint 2 Report', error_list)
-        Sprint.logger.error('#################### ending sprint 2 ... ####################')
+        Sprint.logger.error('######################################## starting sprint 2 ... ########################################')
+        try:
+
+            Tree().grow(fp).pretty_print()
+            usny, usmsk, usam, usdg, usrk = UserStoriesNy(), UserStoriesMSK(), UserStoriesAm(), UserStoriesDg(), UserStoriesRK()
+            error_list.extend(usny.us13(fp))
+            error_list.extend(usny.us19(fp))
+            error_list.extend(usdg.us15(fp))
+            error_list.extend(usdg.us12(fp))
+            error_list.extend(usrk.us14(fp))
+            error_list.extend(usrk.us21(fp))
+            error_list.extend(usam.us11(fp))
+            error_list.extend(usam.us16(fp))
+            TreeUtils.print_report('Sprint 2 Report', error_list)
+        except FileNotFoundError:
+            print(f'File not found: {fp}')
+        Sprint.logger.error('######################################## ending sprint 2 ... ########################################\n')
 
     @staticmethod
     def run_sprint3():
         error_list = []
         fp = get_data_file_path('data_sprint_3.ged')
-        Sprint.logger.error('#################### starting sprint 3 ... ####################')
+        Sprint.logger.error('######################################## starting sprint 3 ... ########################################')
         Tree().grow(fp).pretty_print()
         usny, usmsk, usam, usdg, usrk = UserStoriesNy(), UserStoriesMSK(), UserStoriesAm(), UserStoriesDg(), UserStoriesRK()
         error_list.extend(usny.us22(fp))
         error_list.extend(usny.us26(fp))
         TreeUtils.print_report('Sprint 3 Report', error_list)
-        Sprint.logger.error('#################### ending sprint 3 ... ####################')
+        Sprint.logger.error('######################################## ending sprint 3 ... ########################################\n')
 
     @staticmethod
     def run_sprint_test():

--- a/com/familytree/stories/UserStoriesNy.py
+++ b/com/familytree/stories/UserStoriesNy.py
@@ -3,7 +3,7 @@ from com.familytree.TreeError import TreeError
 from com.familytree.TreeLine import TreeLine
 from com.familytree.Tree import Tree
 from com.familytree.TreeUtils import TreeUtils, date_greater_than, date_equal_to, add_to_date, get_data_file_path, \
-    get_id_list
+    get_id_list, print_list
 
 
 class UserStoriesNy:
@@ -95,9 +95,10 @@ class UserStoriesNy:
                         f', {sibling.get_birth_date(TreeUtils.OUTPUT_DATE_FORMAT)} less than 8 months and more than 1 day apart'
                     err_id_1 = indi.id
                     err_id_2 = sibling.id
-
-                    indi.err = TreeError(TreeError.TYPE_ERROR, TreeError.ON_INDI, 'US13', indi.id, warn_msg)
-                    us13_fail.append(indi)
+                    # indi.err = TreeError(TreeError.TYPE_ERROR, TreeError.ON_INDI, 'US13', indi.id, warn_msg)
+                    indi.add_err(TreeError.TYPE_ERROR, 'US13', warn_msg)
+            if indi.err or indi.err_list:
+                us13_fail.append(indi)
 
         return us13_fail
 
@@ -114,8 +115,10 @@ class UserStoriesNy:
             if common_indi_list:
                 for cousin in common_indi_list:
                     warn_msg = f'{indi.name} married first cousin {cousin.name}'
-                    indi.err = TreeError(TreeError.TYPE_ERROR, TreeError.ON_INDI, 'US19', indi.id, warn_msg)
-                    us19_fail.append(indi)
+                    # indi.err = TreeError(TreeError.TYPE_ERROR, TreeError.ON_INDI, 'US19', indi.id, warn_msg)
+                    indi.add_err(TreeError.TYPE_ERROR, 'US19', warn_msg)
+            if indi.err or indi.err_list:
+                us19_fail.append(indi)
 
         return us19_fail
 

--- a/run_app.py
+++ b/run_app.py
@@ -2,5 +2,5 @@ from com.familytree.sprints.Sprint import Sprint
 
 Sprint.run_sprint1()
 Sprint.run_sprint2()
-Sprint.run_sprint3()
+# Sprint.run_sprint3()
 # Sprint.run_sprint_test()


### PR DESCRIPTION
removing Sprint.sprint3() call
adding err_list list instance variable in Family and Individual objects
print_report method change to support both err and err_list objects in dataobjects